### PR TITLE
take maxRetries into use when block manager port is given

### DIFF
--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -489,8 +489,9 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
         val slaveId = offer.getSlaveId.getValue
         val offerId = offer.getId.getValue
         val resources = remainingResources(offerId)
+        val maxRetries = sc.conf.getOption("spark.port.maxRetries").map(_.toInt).getOrElse(16)
 
-        if (canLaunchTask(slaveId, offer.getHostname, resources)) {
+        if (canLaunchTask(slaveId, offer.getHostname, resources, maxRetries)) {
           // Create a task
           launchTasks = true
           val taskId = newMesosTaskId()
@@ -504,7 +505,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
           slaves.getOrElseUpdate(slaveId, new Slave(offer.getHostname)).taskIDs.add(taskId)
 
           val (resourcesLeft, resourcesToUse) =
-            partitionTaskResources(resources, taskCPUs, taskMemory, taskGPUs)
+            partitionTaskResources(resources, taskCPUs, taskMemory, taskGPUs, maxRetries)
 
           val taskBuilder = MesosTaskInfo.newBuilder()
             .setTaskId(TaskID.newBuilder().setValue(taskId.toString).build())
@@ -533,12 +534,14 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
   }
 
   /** Extracts task needed resources from a list of available resources. */
+  /** Extracts task needed resources from a list of available resources. */
   private def partitionTaskResources(
-      resources: JList[Resource],
-      taskCPUs: Int,
-      taskMemory: Int,
-      taskGPUs: Int)
-    : (List[Resource], List[Resource]) = {
+                                      resources: JList[Resource],
+                                      taskCPUs: Int,
+                                      taskMemory: Int,
+                                      taskGPUs: Int,
+                                      maxRetries: Int)
+  : (List[Resource], List[Resource]) = {
 
     // partition cpus & mem
     val (afterCPUResources, cpuResourcesToUse) = partitionResources(resources, "cpus", taskCPUs)
@@ -551,20 +554,20 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
     // on the same host. This essentially means one executor per host.
     // TODO: handle network isolator case
     val (nonPortResources, portResourcesToUse) =
-      partitionPortResources(nonZeroPortValuesFromConfig(sc.conf), afterGPUResources)
+    partitionPortResources(nonZeroPortValuesFromConfig(sc.conf), afterGPUResources, maxRetries)
 
     (nonPortResources,
       cpuResourcesToUse ++ memResourcesToUse ++ portResourcesToUse ++ gpuResourcesToUse)
   }
 
   private def canLaunchTask(slaveId: String, offerHostname: String,
-                            resources: JList[Resource]): Boolean = {
+                            resources: JList[Resource], maxRetries: Int): Boolean = {
     val offerMem = getResource(resources, "mem")
     val offerCPUs = getResource(resources, "cpus").toInt
     val cpus = executorCores(offerCPUs)
     val mem = executorMemory(sc)
     val ports = getRangeResource(resources, "ports")
-    val meetsPortRequirements = checkPorts(sc.conf, ports)
+    val meetsPortRequirements = checkPorts(sc.conf, ports, maxRetries)
 
     cpus > 0 &&
       cpus <= offerCPUs &&

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -489,7 +489,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
         val slaveId = offer.getSlaveId.getValue
         val offerId = offer.getId.getValue
         val resources = remainingResources(offerId)
-        val maxRetries = sc.conf.getOption("spark.port.maxRetries").map(_.toInt).getOrElse(16)
+        val maxRetries = Utils.portMaxRetries(sc.conf)
 
         if (canLaunchTask(slaveId, offer.getHostname, resources, maxRetries)) {
           // Create a task

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtils.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtils.scala
@@ -412,19 +412,25 @@ trait MesosSchedulerUtils extends Logging {
    * @param ports the list of ports to check
    * @return true if ports are within range false otherwise
    */
-  protected def checkPorts(conf: SparkConf, ports: List[(Long, Long)]): Boolean = {
+  protected def checkPorts(conf: SparkConf, ports: List[(Long, Long)], maxRetries: Int): Boolean = {
 
-    def checkIfInRange(port: Long, ps: List[(Long, Long)]): Boolean = {
-      ps.exists{case (rangeStart, rangeEnd) => rangeStart <= port & rangeEnd >= port }
+    def checkIfInRange(portToTry: Long, ps: List[(Long, Long)]): Boolean = {
+      (portToTry to portToTry + maxRetries).foldLeft(false) {
+        (result, port) => result || ps.exists {
+          case (rangeStart, rangeEnd) => rangeStart <= port && rangeEnd >= port
+        }
+      }
     }
 
     val portsToCheck = nonZeroPortValuesFromConfig(conf)
     val withinRange = portsToCheck.forall(p => checkIfInRange(p, ports))
     // make sure we have enough ports to allocate per offer
-    val enoughPorts =
-    ports.map{case (rangeStart, rangeEnd) => rangeEnd - rangeStart + 1}.sum >= portsToCheck.size
+    val enoughPorts = ports.map {
+      case (rangeStart, rangeEnd) => rangeEnd - rangeStart + 1
+    }.sum >= portsToCheck.size
     enoughPorts && withinRange
   }
+
 
   /**
    * Partitions port resources.
@@ -433,8 +439,9 @@ trait MesosSchedulerUtils extends Logging {
    * @param offeredResources the resources offered
    * @return resources left, port resources to be used.
    */
-  def partitionPortResources(requestedPorts: List[Long], offeredResources: List[Resource])
-    : (List[Resource], List[Resource]) = {
+  def partitionPortResources(requestedPorts: List[Long],
+                             offeredResources: List[Resource], maxRetries: Int)
+  : (List[Resource], List[Resource]) = {
     if (requestedPorts.isEmpty) {
       (offeredResources, List[Resource]())
     } else {
@@ -442,7 +449,7 @@ trait MesosSchedulerUtils extends Logging {
       val (resourcesWithoutPorts, portResources) = filterPortResources(offeredResources)
 
       val portsAndResourceInfo = requestedPorts.
-        map { x => (x, findPortAndGetAssignedResourceInfo(x, portResources)) }
+        map { x => findPortAndGetAssignedResourceInfo(x, portResources, maxRetries) }
 
       val assignedPortResources = createResourcesFromPorts(portsAndResourceInfo)
 
@@ -497,25 +504,37 @@ trait MesosSchedulerUtils extends Logging {
     }
   }
 
- /**
+  /**
   * Helper to assign a port to an offered range and get the latter's role
   * info to use it later on.
   */
-  private def findPortAndGetAssignedResourceInfo(port: Long, portResources: List[Resource])
-    : RoleResourceInfo = {
+  private def findPortAndGetAssignedResourceInfo(port: Long, portResources: List[Resource],
+                                                 maxRetries: Int): (Long, RoleResourceInfo) = {
 
-    val ranges = portResources.
+    val ranges: List[(RoleResourceInfo, List[(Long, Long)])] = portResources.
       map { resource =>
         val reservation = getReservation(resource)
         (RoleResourceInfo(resource.getRole, reservation),
           resource.getRanges.getRangeList.asScala.map(r => (r.getBegin, r.getEnd)).toList)
       }
 
-    val rangePortResourceInfo = ranges
-      .find { case (resourceInfo, rangeList) => rangeList
-        .exists{ case (rangeStart, rangeEnd) => rangeStart <= port & rangeEnd >= port}}
+    @scala.annotation.tailrec
+    def findRangePortResourceInfo(portToTry: Long): (Long, Option[(RoleResourceInfo, List[(Long, Long)])]) = {
+      (ranges.find {
+        case (resourceInfo, rangeList) =>
+          rangeList.exists {
+            case (rangeStart, rangeEnd) => rangeStart <= portToTry && rangeEnd >= portToTry
+          }
+      }) match {
+        case None if portToTry < port + maxRetries => findRangePortResourceInfo(portToTry + 1)
+        case None => (port, None)
+        case result => (portToTry, result)
+      }
+    }
+
     // this is safe since we have previously checked about the ranges (see checkPorts method)
-    rangePortResourceInfo.map{ case (resourceInfo, rangeList) => resourceInfo}.get
+    val (freePort, rangePortResourceInfo) = findRangePortResourceInfo(port)
+    (freePort, rangePortResourceInfo.map{ case (resourceInfo, _) => resourceInfo}.get)
   }
 
   /** Retrieves the port resources from a list of mesos offered resources */

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtilsSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtilsSuite.scala
@@ -183,7 +183,7 @@ class MesosSchedulerUtilsSuite extends SparkFunSuite with Matchers with MockitoS
     val portResource = createTestPortResource((3000, 5000), Some("my_role"))
 
     val (resourcesLeft, resourcesToBeUsed) = utils
-      .partitionPortResources(List(4000), List(portResource), 16)
+      .partitionPortResources(List(4000), List(portResource), org.apache.spark.util.Utils.portMaxRetries(conf))
     resourcesToBeUsed.length shouldBe 1
 
     val portsToUse = getRangesFromResources(resourcesToBeUsed).map{r => r._1}.toArray
@@ -204,7 +204,7 @@ class MesosSchedulerUtilsSuite extends SparkFunSuite with Matchers with MockitoS
     val portResource = createTestPortResource((4001, 5000), Some("my_role"))
 
     val (resourcesLeft, resourcesToBeUsed) = utils
-      .partitionPortResources(List(4000), List(portResource), 16)
+      .partitionPortResources(List(4000), List(portResource), org.apache.spark.util.Utils.portMaxRetries(conf))
     resourcesToBeUsed.length shouldBe 1
 
     val portsToUse = getRangesFromResources(resourcesToBeUsed).map{r => r._1}.toArray
@@ -224,7 +224,7 @@ class MesosSchedulerUtilsSuite extends SparkFunSuite with Matchers with MockitoS
     val portResource = createTestPortResource((3000L, 5000L), Some("my_role"))
 
     val (resourcesLeft, resourcesToBeUsed) = utils
-      .partitionPortResources(List(), List(portResource), 16)
+      .partitionPortResources(List(), List(portResource), org.apache.spark.util.Utils.portMaxRetries(conf))
     val portsToUse = getRangesFromResources(resourcesToBeUsed).map{r => r._1}
 
     portsToUse.isEmpty shouldBe true
@@ -236,7 +236,7 @@ class MesosSchedulerUtilsSuite extends SparkFunSuite with Matchers with MockitoS
     val portResourceList = List(createTestPortResource((3000, 5000), Some("my_role")),
       createTestPortResource((2000, 2500), Some("other_role")))
     val (resourcesLeft, resourcesToBeUsed) = utils
-      .partitionPortResources(List(4000), portResourceList, 16)
+      .partitionPortResources(List(4000), portResourceList, org.apache.spark.util.Utils.portMaxRetries(conf))
     val portsToUse = getRangesFromResources(resourcesToBeUsed).map{r => r._1}
 
     portsToUse.length shouldBe 1
@@ -254,7 +254,7 @@ class MesosSchedulerUtilsSuite extends SparkFunSuite with Matchers with MockitoS
     val portResourceList = List(createTestPortResource((3000, 5000), Some("my_role")),
       createTestPortResource((2000, 2500), Some("other_role")))
     val (resourcesLeft, resourcesToBeUsed) = utils
-      .partitionPortResources(List(), portResourceList, 16)
+      .partitionPortResources(List(), portResourceList, org.apache.spark.util.Utils.portMaxRetries(conf))
     val portsToUse = getRangesFromResources(resourcesToBeUsed).map{r => r._1}
     portsToUse.isEmpty shouldBe true
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The change is for Mesos scheduler when Mesos cluster manager is used.

Use 'spark.port.maxRetries' while handling offered executor resources so that the whole port range (spark.blockManager.port + spark.port.maxRetries) is considered - not only 'spark.blockManager.port ' as earlier. When 'spark.blockManager.port ' is specified it is now possible to get (spark.blockManager.port + spark.port.maxRetries) executors running for each node - not only one as earlier.

The fix will enable network isolation and makes it possible to specify network policies for the specific port ranges (spark.blockManager.port + spark.port.maxRetries).

## How was this patch tested?

A unit test was added for checking that resource is accepted also when 'spark.blockManager.port' is not in given port range, but port range includes a port from range 'spark.blockManager.port + spark.port.maxRetries'.

The binary was build and all the unit tests were run and this binary was used in a real test environment and tested manually by checking that the range 'spark.blockManager.port + spark.port.maxRetries' was obeyed and it was possible to launch 'spark.port.maxRetries' executors (when there were enough CPU and memory resources available) for each node.

It was also tested that the random port ('spark.blockManager.port' is not given or is set to 0) is still working as earlier.

Please review http://spark.apache.org/contributing.html before opening a pull request.
