### PR TITLE
take maxRetries into use when block manager port is given

### DIFF
--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtilsSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtilsSuite.scala
@@ -183,7 +183,7 @@ class MesosSchedulerUtilsSuite extends SparkFunSuite with Matchers with MockitoS
     val portResource = createTestPortResource((3000, 5000), Some("my_role"))
 
     val (resourcesLeft, resourcesToBeUsed) = utils
-      .partitionPortResources(List(4000), List(portResource))
+      .partitionPortResources(List(4000), List(portResource), org.apache.spark.util.Utils.portMaxRetries(conf))
     resourcesToBeUsed.length shouldBe 1
 
     val portsToUse = getRangesFromResources(resourcesToBeUsed).map{r => r._1}.toArray
@@ -198,12 +198,33 @@ class MesosSchedulerUtilsSuite extends SparkFunSuite with Matchers with MockitoS
     arePortsEqual(portRangesToBeUsed.toArray, expectedUSed) shouldBe true
   }
 
+  test("Port reservation is done correctly with user specified ports only taking max retry into use") {
+    val conf = new SparkConf()
+    conf.set(BLOCK_MANAGER_PORT, 4000)
+    val portResource = createTestPortResource((4001, 5000), Some("my_role"))
+
+    val (resourcesLeft, resourcesToBeUsed) = utils
+      .partitionPortResources(List(4000), List(portResource), org.apache.spark.util.Utils.portMaxRetries(conf))
+    resourcesToBeUsed.length shouldBe 1
+
+    val portsToUse = getRangesFromResources(resourcesToBeUsed).map{r => r._1}.toArray
+
+    portsToUse.length shouldBe 1
+    arePortsEqual(portsToUse, Array(4001L)) shouldBe true
+
+    val portRangesToBeUsed = rangesResourcesToTuple(resourcesToBeUsed)
+
+    val expectedUsed = Array((4001L, 4001L))
+
+    arePortsEqual(portRangesToBeUsed.toArray, expectedUsed) shouldBe true
+  }
+
   test("Port reservation is done correctly with all random ports") {
     val conf = new SparkConf()
     val portResource = createTestPortResource((3000L, 5000L), Some("my_role"))
 
     val (resourcesLeft, resourcesToBeUsed) = utils
-      .partitionPortResources(List(), List(portResource))
+      .partitionPortResources(List(), List(portResource), org.apache.spark.util.Utils.portMaxRetries(conf))
     val portsToUse = getRangesFromResources(resourcesToBeUsed).map{r => r._1}
 
     portsToUse.isEmpty shouldBe true
@@ -215,7 +236,7 @@ class MesosSchedulerUtilsSuite extends SparkFunSuite with Matchers with MockitoS
     val portResourceList = List(createTestPortResource((3000, 5000), Some("my_role")),
       createTestPortResource((2000, 2500), Some("other_role")))
     val (resourcesLeft, resourcesToBeUsed) = utils
-      .partitionPortResources(List(4000), portResourceList)
+      .partitionPortResources(List(4000), portResourceList, org.apache.spark.util.Utils.portMaxRetries(conf))
     val portsToUse = getRangesFromResources(resourcesToBeUsed).map{r => r._1}
 
     portsToUse.length shouldBe 1
@@ -233,7 +254,7 @@ class MesosSchedulerUtilsSuite extends SparkFunSuite with Matchers with MockitoS
     val portResourceList = List(createTestPortResource((3000, 5000), Some("my_role")),
       createTestPortResource((2000, 2500), Some("other_role")))
     val (resourcesLeft, resourcesToBeUsed) = utils
-      .partitionPortResources(List(), portResourceList)
+      .partitionPortResources(List(), portResourceList, org.apache.spark.util.Utils.portMaxRetries(conf))
     val portsToUse = getRangesFromResources(resourcesToBeUsed).map{r => r._1}
     portsToUse.isEmpty shouldBe true
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

The change is for Mesos scheduler when Mesos cluster manager is used.

Use 'spark.port.maxRetries' while handling offered executor resources so that the whole port range (spark.blockManager.port + spark.port.maxRetries) is considered - not only 'spark.blockManager.port ' as earlier. When 'spark.blockManager.port ' is specified it is now possible to get (spark.blockManager.port + spark.port.maxRetries) executors running for each node - not only one as earlier.

### Why are the changes needed?

The fix will enable network isolation and makes it possible to specify network policies for the specific port ranges (spark.blockManager.port + spark.port.maxRetries).

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

A unit test was added for checking that resource is accepted also when 'spark.blockManager.port' is not in given port range, but port range includes a port from range 'spark.blockManager.port + spark.port.maxRetries'.

The binary was build and all the unit tests were run and this binary was used in a real test environment and tested manually by checking that the range 'spark.blockManager.port + spark.port.maxRetries' was obeyed and it was possible to launch 'spark.port.maxRetries' executors (when there were enough CPU and memory resources available) for each node.

It was also tested that the random port ('spark.blockManager.port' is not given or is set to 0) is still working as earlier.
