### PR TITLE
take maxRetries into use when block manager port is given

### DIFF
--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackend.scala
@@ -492,8 +492,9 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
         val slaveId = offer.getSlaveId.getValue
         val offerId = offer.getId.getValue
         val resources = remainingResources(offerId)
+        val maxRetries = Utils.portMaxRetries(sc.conf)
 
-        if (canLaunchTask(slaveId, offer.getHostname, resources)) {
+        if (canLaunchTask(slaveId, offer.getHostname, resources, maxRetries)) {
           // Create a task
           launchTasks = true
           val taskId = newMesosTaskId()
@@ -507,7 +508,7 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
           slaves.getOrElseUpdate(slaveId, new Slave(offer.getHostname)).taskIDs.add(taskId)
 
           val (resourcesLeft, resourcesToUse) =
-            partitionTaskResources(resources, taskCPUs, taskMemory, taskGPUs)
+            partitionTaskResources(resources, taskCPUs, taskMemory, taskGPUs, maxRetries)
 
           val taskBuilder = MesosTaskInfo.newBuilder()
             .setTaskId(TaskID.newBuilder().setValue(taskId.toString).build())
@@ -540,7 +541,8 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
       resources: JList[Resource],
       taskCPUs: Int,
       taskMemory: Int,
-      taskGPUs: Int)
+      taskGPUs: Int,
+      maxRetries: Int)
     : (List[Resource], List[Resource]) = {
 
     // partition cpus & mem
@@ -554,20 +556,20 @@ private[spark] class MesosCoarseGrainedSchedulerBackend(
     // on the same host. This essentially means one executor per host.
     // TODO: handle network isolator case
     val (nonPortResources, portResourcesToUse) =
-      partitionPortResources(nonZeroPortValuesFromConfig(sc.conf), afterGPUResources)
+      partitionPortResources(nonZeroPortValuesFromConfig(sc.conf), afterGPUResources, maxRetries)
 
     (nonPortResources,
       cpuResourcesToUse ++ memResourcesToUse ++ portResourcesToUse ++ gpuResourcesToUse)
   }
 
   private def canLaunchTask(slaveId: String, offerHostname: String,
-                            resources: JList[Resource]): Boolean = {
+                            resources: JList[Resource], maxRetries: Int): Boolean = {
     val offerMem = getResource(resources, "mem")
     val offerCPUs = getResource(resources, "cpus").toInt
     val cpus = executorCores(offerCPUs)
     val mem = executorMemory(sc)
     val ports = getRangeResource(resources, "ports")
-    val meetsPortRequirements = checkPorts(sc.conf, ports)
+    val meetsPortRequirements = checkPorts(sc.conf, ports, maxRetries)
 
     cpus > 0 &&
       cpus <= offerCPUs &&

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtils.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtils.scala
@@ -439,17 +439,22 @@ trait MesosSchedulerUtils extends Logging {
    * @param ports the list of ports to check
    * @return true if ports are within range false otherwise
    */
-  protected def checkPorts(conf: SparkConf, ports: List[(Long, Long)]): Boolean = {
+  protected def checkPorts(conf: SparkConf, ports: List[(Long, Long)], maxRetries: Int): Boolean = {
 
-    def checkIfInRange(port: Long, ps: List[(Long, Long)]): Boolean = {
-      ps.exists{case (rangeStart, rangeEnd) => rangeStart <= port & rangeEnd >= port }
+    def checkIfInRange(portToTry: Long, ps: List[(Long, Long)]): Boolean = {
+      (portToTry to portToTry + maxRetries).foldLeft(false) {
+        (result, port) => result || ps.exists {
+          case (rangeStart, rangeEnd) => rangeStart <= port && rangeEnd >= port
+        }
+      }
     }
 
     val portsToCheck = nonZeroPortValuesFromConfig(conf)
     val withinRange = portsToCheck.forall(p => checkIfInRange(p, ports))
     // make sure we have enough ports to allocate per offer
-    val enoughPorts =
-    ports.map{case (rangeStart, rangeEnd) => rangeEnd - rangeStart + 1}.sum >= portsToCheck.size
+    val enoughPorts = ports.map {
+      case (rangeStart, rangeEnd) => rangeEnd - rangeStart + 1
+    }.sum >= portsToCheck.size
     enoughPorts && withinRange
   }
 
@@ -460,7 +465,9 @@ trait MesosSchedulerUtils extends Logging {
    * @param offeredResources the resources offered
    * @return resources left, port resources to be used.
    */
-  def partitionPortResources(requestedPorts: List[Long], offeredResources: List[Resource])
+  def partitionPortResources(requestedPorts: List[Long],
+                             offeredResources: List[Resource],
+                             maxRetries: Int)
     : (List[Resource], List[Resource]) = {
     if (requestedPorts.isEmpty) {
       (offeredResources, List[Resource]())
@@ -469,7 +476,7 @@ trait MesosSchedulerUtils extends Logging {
       val (resourcesWithoutPorts, portResources) = filterPortResources(offeredResources)
 
       val portsAndResourceInfo = requestedPorts.
-        map { x => (x, findPortAndGetAssignedResourceInfo(x, portResources)) }
+        map { x => findPortAndGetAssignedResourceInfo(x, portResources, maxRetries) }
 
       val assignedPortResources = createResourcesFromPorts(portsAndResourceInfo)
 
@@ -528,21 +535,32 @@ trait MesosSchedulerUtils extends Logging {
   * Helper to assign a port to an offered range and get the latter's role
   * info to use it later on.
   */
-  private def findPortAndGetAssignedResourceInfo(port: Long, portResources: List[Resource])
-    : RoleResourceInfo = {
+  private def findPortAndGetAssignedResourceInfo(port: Long, portResources: List[Resource],
+                                                 maxRetries: Int): (Long, RoleResourceInfo) = {
 
-    val ranges = portResources.
+    val ranges: List[(RoleResourceInfo, List[(Long, Long)])] = portResources.
       map { resource =>
         val reservation = getReservation(resource)
         (RoleResourceInfo(resource.getRole, reservation),
           resource.getRanges.getRangeList.asScala.map(r => (r.getBegin, r.getEnd)).toList)
       }
 
-    val rangePortResourceInfo = ranges
-      .find { case (resourceInfo, rangeList) => rangeList
-        .exists{ case (rangeStart, rangeEnd) => rangeStart <= port & rangeEnd >= port}}
-    // this is safe since we have previously checked about the ranges (see checkPorts method)
-    rangePortResourceInfo.map{ case (resourceInfo, rangeList) => resourceInfo}.get
+    @scala.annotation.tailrec
+    def findRangePortResourceInfo(portToTry: Long): (Long, Option[(RoleResourceInfo, List[(Long, Long)])]) = {
+      (ranges.find {
+        case (resourceInfo, rangeList) =>
+          rangeList.exists {
+            case (rangeStart, rangeEnd) => rangeStart <= portToTry && rangeEnd >= portToTry
+          }
+      }) match {
+        case None if portToTry < port + maxRetries => findRangePortResourceInfo(portToTry + 1)
+        case None => (port, None)
+        case result => (portToTry, result)
+      }
+    }
+
+    val (freePort, rangePortResourceInfo) = findRangePortResourceInfo(port)
+    (freePort, rangePortResourceInfo.map{ case (resourceInfo, _) => resourceInfo}.get)
   }
 
   /** Retrieves the port resources from a list of mesos offered resources */

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtilsSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtilsSuite.scala
@@ -187,7 +187,7 @@ class MesosSchedulerUtilsSuite extends SparkFunSuite with Matchers with MockitoS
     val portResource = createTestPortResource((3000, 5000), Some("my_role"))
 
     val (resourcesLeft, resourcesToBeUsed) = utils
-      .partitionPortResources(List(4000), List(portResource))
+      .partitionPortResources(List(4000), List(portResource), org.apache.spark.util.Utils.portMaxRetries(conf))
     resourcesToBeUsed.length shouldBe 1
 
     val portsToUse = getRangesFromResources(resourcesToBeUsed).map{r => r._1}.toArray
@@ -202,12 +202,33 @@ class MesosSchedulerUtilsSuite extends SparkFunSuite with Matchers with MockitoS
     arePortsEqual(portRangesToBeUsed.toArray, expectedUSed) shouldBe true
   }
 
+  test("Port reservation is done correctly with user specified ports only taking max retry into use") {
+    val conf = new SparkConf()
+    conf.set(BLOCK_MANAGER_PORT, 4000)
+    val portResource = createTestPortResource((4001, 5000), Some("my_role"))
+
+    val (resourcesLeft, resourcesToBeUsed) = utils
+      .partitionPortResources(List(4000), List(portResource), org.apache.spark.util.Utils.portMaxRetries(conf))
+    resourcesToBeUsed.length shouldBe 1
+
+    val portsToUse = getRangesFromResources(resourcesToBeUsed).map{r => r._1}.toArray
+
+    portsToUse.length shouldBe 1
+    arePortsEqual(portsToUse, Array(4001L)) shouldBe true
+
+    val portRangesToBeUsed = rangesResourcesToTuple(resourcesToBeUsed)
+
+    val expectedUsed = Array((4001L, 4001L))
+
+    arePortsEqual(portRangesToBeUsed.toArray, expectedUsed) shouldBe true
+  }
+
   test("Port reservation is done correctly with all random ports") {
     val conf = new SparkConf()
     val portResource = createTestPortResource((3000L, 5000L), Some("my_role"))
 
     val (resourcesLeft, resourcesToBeUsed) = utils
-      .partitionPortResources(List(), List(portResource))
+      .partitionPortResources(List(), List(portResource), org.apache.spark.util.Utils.portMaxRetries(conf))
     val portsToUse = getRangesFromResources(resourcesToBeUsed).map{r => r._1}
 
     portsToUse.isEmpty shouldBe true
@@ -219,7 +240,7 @@ class MesosSchedulerUtilsSuite extends SparkFunSuite with Matchers with MockitoS
     val portResourceList = List(createTestPortResource((3000, 5000), Some("my_role")),
       createTestPortResource((2000, 2500), Some("other_role")))
     val (resourcesLeft, resourcesToBeUsed) = utils
-      .partitionPortResources(List(4000), portResourceList)
+      .partitionPortResources(List(4000), portResourceList, org.apache.spark.util.Utils.portMaxRetries(conf))
     val portsToUse = getRangesFromResources(resourcesToBeUsed).map{r => r._1}
 
     portsToUse.length shouldBe 1
@@ -237,7 +258,7 @@ class MesosSchedulerUtilsSuite extends SparkFunSuite with Matchers with MockitoS
     val portResourceList = List(createTestPortResource((3000, 5000), Some("my_role")),
       createTestPortResource((2000, 2500), Some("other_role")))
     val (resourcesLeft, resourcesToBeUsed) = utils
-      .partitionPortResources(List(), portResourceList)
+      .partitionPortResources(List(), portResourceList, org.apache.spark.util.Utils.portMaxRetries(conf))
     val portsToUse = getRangesFromResources(resourcesToBeUsed).map{r => r._1}
     portsToUse.isEmpty shouldBe true
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

The change is for Mesos scheduler when Mesos cluster manager is used.

Use 'spark.port.maxRetries' while handling offered executor resources so that the whole port range (spark.blockManager.port + spark.port.maxRetries) is considered - not only 'spark.blockManager.port ' as earlier. When 'spark.blockManager.port ' is specified it is now possible to get (spark.blockManager.port + spark.port.maxRetries) executors running for each node - not only one as earlier.

### Why are the changes needed?

The fix will enable network isolation and makes it possible to specify network policies for the specific port ranges (spark.blockManager.port + spark.port.maxRetries).

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

A unit test was added for checking that resource is accepted also when 'spark.blockManager.port' is not in given port range, but port range includes a port from range 'spark.blockManager.port + spark.port.maxRetries'.

The binary was build and all the unit tests were run and this binary was used in a real test environment and tested manually by checking that the range 'spark.blockManager.port + spark.port.maxRetries' was obeyed and it was possible to launch 'spark.port.maxRetries' executors (when there were enough CPU and memory resources available) for each node.

It was also tested that the random port ('spark.blockManager.port' is not given or is set to 0) is still working as earlier.
